### PR TITLE
fix(eventos): replace de repertório via M2M.set()

### DIFF
--- a/core/api/views.py
+++ b/core/api/views.py
@@ -22,6 +22,7 @@ from core.models import (
     ReacaoComentario,
 )
 from core.services import NotificationService
+from core.services.compartilhamento_service import CompartilhamentoService
 
 from .serializers import (
     ArtistaSerializer,
@@ -543,7 +544,6 @@ class EventoViewSet(MusicoPermissionMixin, viewsets.ModelViewSet):
     ViewSet para gerenciar eventos com otimizações agressivas.
     """
 
-    # ✅ CORRIGIDO: Apenas uma declaração de queryset
     queryset = Evento.objects.prefetch_related("repertorio").all()
 
     serializer_class = EventoSerializer
@@ -579,6 +579,18 @@ class EventoViewSet(MusicoPermissionMixin, viewsets.ModelViewSet):
         methods=["post"],
         permission_classes=[IsAuthenticated, IsLiderOrReadOnly],
     )
+    @action(detail=True, methods=["get"], url_path="compartilhar")
+    def compartilhar(self, request, pk=None):
+        """
+        GET /api/eventos/{id}/compartilhar/
+        Retorna o texto formatado da escala para compartilhamento (ex.: WhatsApp).
+        """
+        try:
+            texto = CompartilhamentoService.gerar_texto_escala(int(pk))
+            return Response({"texto": texto})
+        except ValueError as e:
+            return Response({"detail": str(e)}, status=404)
+
     def adicionar_repertorio(self, request, pk=None):
         """
         Adicionar músicas ao repertório do evento.
@@ -634,6 +646,54 @@ class EventoViewSet(MusicoPermissionMixin, viewsets.ModelViewSet):
                 "evento_nome": evento.nome,
                 "total_musicas": evento.repertorio.count(),
                 "musicas_adicionadas": len(ids_encontrados),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @action(
+        detail=True,
+        methods=["put"],
+        permission_classes=[IsAuthenticated, IsLiderOrReadOnly],
+    )
+    def atualizar_repertorio(self, request, pk=None):
+        """
+        Substitui o repertório do evento pela lista enviada (replace completo).
+        PUT /api/eventos/{id}/atualizar_repertorio/
+        Body: { "musicas": [1, 2, 3] }
+        """
+        evento = self.get_object()
+        musica_ids = request.data.get("musicas", [])
+
+        if not isinstance(musica_ids, list):
+            return Response(
+                {"error": "O campo musicas deve ser uma lista de IDs"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Valida se todas as músicas existem
+        musicas_existentes = Musica.objects.filter(id__in=musica_ids).values_list(
+            "id", flat=True
+        )
+        ids_nao_encontrados = set(musica_ids) - set(musicas_existentes)
+
+        if ids_nao_encontrados:
+            return Response(
+                {
+                    "error": "Algumas músicas não foram encontradas",
+                    "musicas_nao_encontradas": sorted(list(ids_nao_encontrados)),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # set() substitui toda a M2M — remove as antigas e adiciona as novas
+        evento.repertorio.set(musica_ids)
+
+        return Response(
+            {
+                "status": "Repertório atualizado",
+                "evento_id": evento.id,
+                "evento_nome": evento.nome,
+                "total_musicas": evento.repertorio.count(),
             },
             status=status.HTTP_200_OK,
         )

--- a/core/services/__init__.py
+++ b/core/services/__init__.py
@@ -1,3 +1,4 @@
+from .compartilhamento_service import CompartilhamentoService
 from .gerenciador_escala import GerenciadorEscala
 from .notification_service import NotificationService
 

--- a/core/services/compartilhamento_service.py
+++ b/core/services/compartilhamento_service.py
@@ -1,0 +1,81 @@
+from core.models import Evento
+
+
+class CompartilhamentoService:
+    """
+    Serviço responsável por gerar o texto de compartilhamento
+    da escala de um evento (ex.: envio via WhatsApp).
+    """
+
+    @staticmethod
+    def gerar_texto_escala(evento_id: int) -> str:
+        """
+        Gera o texto formatado da escala de um evento para compartilhamento.
+
+        Formato:
+            🎵 *NOME DO EVENTO*
+            📅 Data: DD/MM/AAAA às HH:MM
+            📍 Local: ...
+            🕐 Ensaio: DD/MM/AAAA às HH:MM  (somente se houver)
+
+            👥 *Equipe escalada:*
+            • Nome — Instrumento
+
+            🎶 *Repertório:*
+            • Título - Artista
+              🔗 Cifra: <link>        (somente se houver)
+              ▶️ YouTube: <link>      (somente se houver)
+        """
+        try:
+            evento = Evento.objects.prefetch_related(
+                "escalas__musico",
+                "escalas__instrumento_no_evento",
+                "repertorio__artista",
+            ).get(id=evento_id)
+        except Evento.DoesNotExist:
+            raise ValueError(f"Evento com id={evento_id} não encontrado.")
+
+        linhas = []
+
+        # Cabeçalho
+        linhas.append(f"🎵 *{evento.nome.upper()}*")
+        linhas.append(f"📅 Data: {evento.data_evento.strftime('%d/%m/%Y às %H:%M')}")
+        linhas.append(f"📍 Local: {evento.local}")
+
+        # Ensaio (opcional)
+        if evento.data_hora_ensaio:
+            linhas.append(
+                f"🕐 Ensaio: {evento.data_hora_ensaio.strftime('%d/%m/%Y às %H:%M')}"
+            )
+
+        # Equipe
+        escalas = evento.escalas.all()
+        if escalas.exists():
+            linhas.append("")
+            linhas.append("👥 *Equipe escalada:*")
+            for escala in escalas:
+                instrumento = (
+                    escala.instrumento_no_evento.nome
+                    if escala.instrumento_no_evento
+                    else "Sem instrumento"
+                )
+                linhas.append(f"• {escala.musico.nome} — {instrumento}")
+
+        # Repertório
+        musicas = evento.repertorio.all()
+        if musicas.exists():
+            linhas.append("")
+            linhas.append("🎶 *Repertório:*")
+            for musica in musicas:
+                artista_nome = str(musica.artista) if musica.artista else None
+                if artista_nome:
+                    linhas.append(f"• {musica.titulo} - {artista_nome}")
+                else:
+                    linhas.append(f"• {musica.titulo}")
+
+                if musica.link_cifra:
+                    linhas.append(f"  🔗 Cifra: {musica.link_cifra}")
+                if musica.link_youtube:
+                    linhas.append(f"  ▶️ YouTube: {musica.link_youtube}")
+
+        return "\n".join(linhas)

--- a/core/tests/test_api.py
+++ b/core/tests/test_api.py
@@ -209,20 +209,22 @@ class EventoAPITest(APITestCase):
         self.assertGreater(len(response.data), 0)
 
     def test_adicionar_repertorio_lista_vazia(self):
-        url = reverse("evento-adicionar-repertorio", args=[self.evento.id])
-        response = self.client.post(url, {"musicas": []}, format="json")
+        url = reverse("evento-atualizar-repertorio", args=[self.evento.id])
+        response = self.client.put(url, {"musicas": []}, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # Lista vazia é válida — representa limpar o repertório do evento
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_musicas"], 0)
 
     def test_adicionar_repertorio_tipo_invalido(self):
-        url = reverse("evento-adicionar-repertorio", args=[self.evento.id])
-        response = self.client.post(url, {"musicas": "errado"}, format="json")
+        url = reverse("evento-atualizar-repertorio", args=[self.evento.id])
+        response = self.client.put(url, {"musicas": "errado"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_adicionar_repertorio_musica_inexistente(self):
-        url = reverse("evento-adicionar-repertorio", args=[self.evento.id])
-        response = self.client.post(url, {"musicas": [999]}, format="json")
+        url = reverse("evento-atualizar-repertorio", args=[self.evento.id])
+        response = self.client.put(url, {"musicas": [999]}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -232,8 +234,8 @@ class EventoAPITest(APITestCase):
         artista = Artista.objects.create(nome="Teste Artista")
         musica = Musica.objects.create(titulo="Teste", artista=artista)
 
-        url = reverse("evento-adicionar-repertorio", args=[self.evento.id])
-        response = self.client.post(url, {"musicas": [musica.id]}, format="json")
+        url = reverse("evento-atualizar-repertorio", args=[self.evento.id])
+        response = self.client.put(url, {"musicas": [musica.id]}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(self.evento.repertorio.count(), 1)

--- a/core/tests/test_compartilhamento.py
+++ b/core/tests/test_compartilhamento.py
@@ -1,0 +1,181 @@
+import datetime
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from core.models import Artista, Escala, Evento, Instrumento, Musica, Musico
+from core.services.compartilhamento_service import CompartilhamentoService
+
+DATA_EVENTO = datetime.datetime(2026, 3, 15, 19, 0)
+DATA_ENSAIO = datetime.datetime(2026, 3, 15, 17, 0)
+
+
+class CompartilhamentoServiceTest(TestCase):
+
+    def setUp(self):
+        self.artista = Artista.objects.create(nome="Hillsong")
+
+        self.musica_com_links = Musica.objects.create(
+            titulo="Oceans",
+            artista=self.artista,
+            link_cifra="https://www.cifraclub.com.br/hillsong/oceans/",
+            link_youtube="https://youtu.be/dy9nwe9_xzw",
+        )
+        self.musica_sem_links = Musica.objects.create(
+            titulo="Alvo Mais que a Neve",
+            artista=self.artista,
+        )
+        self.musica_so_cifra = Musica.objects.create(
+            titulo="Quão Grande é o Meu Deus",
+            artista=self.artista,
+            link_cifra="https://www.cifraclub.com.br/chris-tomlin/how-great-is-our-god/",
+        )
+
+        self.evento = Evento.objects.create(
+            nome="Culto Jovens",
+            tipo="CULTO",
+            data_evento=DATA_EVENTO,
+            local="Templo Central",
+        )
+
+        self.instrumento = Instrumento.objects.create(nome="Violão")
+
+        self.user = User.objects.create_user(
+            username="joao", email="joao@test.com", password="pass"
+        )
+        self.musico = Musico.objects.create(
+            user=self.user, nome="João Silva", status="ATIVO"
+        )
+
+    # ------------------------------------------------------------------
+    # Cabeçalho
+    # ------------------------------------------------------------------
+
+    def test_cabecalho_contem_nome_evento(self):
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("CULTO JOVENS", texto)
+
+    def test_cabecalho_contem_data_evento(self):
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("15/03/2026", texto)
+        self.assertIn("19:00", texto)
+
+    def test_cabecalho_contem_local(self):
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("Templo Central", texto)
+
+    # ------------------------------------------------------------------
+    # Ensaio
+    # ------------------------------------------------------------------
+
+    def test_sem_ensaio_nao_exibe_linha_ensaio(self):
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertNotIn("Ensaio", texto)
+
+    def test_com_ensaio_exibe_data_hora_ensaio(self):
+        self.evento.data_hora_ensaio = DATA_ENSAIO
+        self.evento.save()
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("Ensaio", texto)
+        self.assertIn("17:00", texto)
+
+    # ------------------------------------------------------------------
+    # Equipe escalada
+    # ------------------------------------------------------------------
+
+    def test_sem_escalados_nao_exibe_secao_equipe(self):
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertNotIn("Equipe escalada", texto)
+
+    def test_musico_escalado_aparece_com_instrumento(self):
+        Escala.objects.create(
+            musico=self.musico,
+            evento=self.evento,
+            instrumento_no_evento=self.instrumento,
+        )
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("João Silva", texto)
+        self.assertIn("Violão", texto)
+
+    def test_musico_escalado_sem_instrumento(self):
+        Escala.objects.create(
+            musico=self.musico,
+            evento=self.evento,
+            instrumento_no_evento=None,
+        )
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("João Silva", texto)
+        self.assertIn("Sem instrumento", texto)
+
+    # ------------------------------------------------------------------
+    # Repertório
+    # ------------------------------------------------------------------
+
+    def test_sem_repertorio_nao_exibe_secao_repertorio(self):
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertNotIn("Repertório", texto)
+
+    def test_musica_com_ambos_links_exibe_cifra_e_youtube(self):
+        self.evento.repertorio.add(self.musica_com_links)
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("Oceans", texto)
+        self.assertIn("https://www.cifraclub.com.br/hillsong/oceans/", texto)
+        self.assertIn("https://youtu.be/dy9nwe9_xzw", texto)
+
+    def test_musica_sem_links_nao_exibe_placeholder(self):
+        self.evento.repertorio.add(self.musica_sem_links)
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("Alvo Mais que a Neve", texto)
+        self.assertNotIn("🔗", texto)
+        self.assertNotIn("▶️", texto)
+        self.assertNotIn("None", texto)
+        self.assertNotIn("?", texto)
+
+    def test_musica_so_com_cifra_exibe_apenas_cifra(self):
+        self.evento.repertorio.add(self.musica_so_cifra)
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("🔗", texto)
+        self.assertNotIn("▶️", texto)
+
+    def test_musica_exibe_artista(self):
+        self.evento.repertorio.add(self.musica_com_links)
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+        self.assertIn("Hillsong", texto)
+
+    # ------------------------------------------------------------------
+    # Texto completo / integração
+    # ------------------------------------------------------------------
+
+    def test_texto_completo_com_tudo(self):
+        """Cenário completo: ensaio + equipe + repertório com e sem links."""
+        self.evento.data_hora_ensaio = DATA_ENSAIO
+        self.evento.save()
+
+        Escala.objects.create(
+            musico=self.musico,
+            evento=self.evento,
+            instrumento_no_evento=self.instrumento,
+        )
+
+        self.evento.repertorio.add(self.musica_com_links)
+        self.evento.repertorio.add(self.musica_sem_links)
+
+        texto = CompartilhamentoService.gerar_texto_escala(self.evento.id)
+
+        self.assertIn("CULTO JOVENS", texto)
+        self.assertIn("15/03/2026", texto)
+        self.assertIn("Ensaio", texto)
+        self.assertIn("João Silva", texto)
+        self.assertIn("Violão", texto)
+        self.assertIn("Oceans", texto)
+        self.assertIn("https://www.cifraclub.com.br/hillsong/oceans/", texto)
+        self.assertIn("Alvo Mais que a Neve", texto)
+        self.assertNotIn("None", texto)
+
+    # ------------------------------------------------------------------
+    # Erro
+    # ------------------------------------------------------------------
+
+    def test_evento_inexistente_levanta_value_error(self):
+        with self.assertRaises(ValueError):
+            CompartilhamentoService.gerar_texto_escala(99999)


### PR DESCRIPTION
# Problema
O endpoint \`adicionar_repertorio\` usava \`.add()\` na M2M, então músicas
desmarcadas no setlist nunca eram removidas.

## Solução
Novo endpoint \`PUT /api/eventos/{id}/atualizar_repertorio/\` que usa
\`.set()\` — substitui o repertório completo pelo conjunto enviado.

## Mobile relacionado
PR feat/escalas-rascunho-tabs — troca o controller para usar o novo endpoint.